### PR TITLE
Adding pyShodan to the list of required python packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ win_inet_pton
 pyExploitDb>=0.1.8
 GitPython
 pandas
+pyShodan


### PR DESCRIPTION
Was trying to run legion and failed to run due to pyShodan not being installed as it was not in the requirements.txt.