### PR TITLE
Extract application metadata from main controller

### DIFF
--- a/app/ApplicationInfo.py
+++ b/app/ApplicationInfo.py
@@ -1,0 +1,38 @@
+"""
+LEGION (https://govanguard.io)
+Copyright (c) 2018 GoVanguard
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+    License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along with this program.
+    If not, see <http://www.gnu.org/licenses/>.
+
+Author(s): Dmitriy Dubson (d.dubson@gmail.com)
+"""
+
+applicationInfo = {
+    "name": "LEGION",
+    "version": "0.3.5",
+    "build": "1565621036",
+    "author": "GoVanguard",
+    "copyright": "2019",
+    "links": ["http://github.com/GoVanguard/legion/issues", "https://GoVanguard.io/legion"],
+    "emails": [],
+    "update": "08/12/2019",
+    "license": "GPL v3",
+    "desc": "Legion is a fork of SECFORCE's Sparta, Legion is an open source, easy-to-use, \n" +
+            "super-extensible and semi-automated network penetration testing tool that aids in " +
+            "discovery, \nreconnaissance and exploitation of information systems.",
+    "smallIcon": "./images/icons/Legion-N_128x128.svg",
+    "bigIcon": "./images/icons/Legion-N_128x128.svg"
+}
+
+
+def getVersion():
+    return f"{applicationInfo['version']}-{applicationInfo['build']}"

--- a/controller/controller.py
+++ b/controller/controller.py
@@ -20,6 +20,7 @@ Copyright (c) 2018 GoVanguard
 import signal  # for file operations, to kill processes, for regex, for subprocesses
 import subprocess
 
+from app.ApplicationInfo import applicationInfo
 from app.Screenshooter import Screenshooter
 from app.actions.updateProgress.UpdateProgressObservable import UpdateProgressObservable
 from app.importers.NmapImporter import NmapImporter
@@ -40,23 +41,6 @@ class Controller:
     # initialisations that will happen once - when the program is launched
     @timing
     def __init__(self, view, logic):
-        self.name = "LEGION"
-        self.version = '0.3.5'
-        self.build = '1565621036'
-        self.author = 'GoVanguard'
-        self.copyright = '2019'
-        self.links = ['http://github.com/GoVanguard/legion/issues', 'https://GoVanguard.io/legion']
-        self.emails = []
-
-        self.update = '08/12/2019'
-
-        self.license = "GPL v3"
-        self.desc = "Legion is a fork of SECFORCE's Sparta, Legion is an open source, easy-to-use, \n" + \
-                    "super-extensible and semi-automated network penetration testing tool that aids in " + \
-                    "discovery, \nreconnaissance and exploitation of information systems."
-        self.smallIcon = './images/icons/Legion-N_128x128.svg'
-        self.bigIcon = './images/icons/Legion-N_128x128.svg'
-
         self.logic = logic
         self.view = view
         self.view.setController(self)
@@ -169,9 +153,6 @@ class Controller:
 
     def getProjectName(self):
         return self.logic.activeProject.properties.projectName
-
-    def getVersion(self):
-        return (self.version + "-" + self.build)
 
     def getRunningFolder(self):
         return self.logic.activeProject.properties.runningFolder

--- a/ui/view.py
+++ b/ui/view.py
@@ -22,6 +22,7 @@ from PyQt5.QtCore import *                                              # for fi
 from PyQt5 import QtCore
 from PyQt5 import QtWidgets, QtGui, QtCore
 
+from app.ApplicationInfo import applicationInfo, getVersion
 from app.shell.Shell import Shell
 from app.timing import getTimestamp
 from ui.ViewState import ViewState
@@ -75,10 +76,10 @@ class View(QtCore.QObject):
         self.importProgressWidget = ProgressWidget('Importing nmap..', self.ui.centralwidget)
         self.adddialog = AddHostsDialog(self.ui.centralwidget)      
         self.settingsWidget = AddSettingsDialog(self.shell, self.ui.centralwidget)
-        self.helpDialog = HelpDialog(self.controller.name, self.controller.author, self.controller.copyright,
-                                     self.controller.links, self.controller.emails, self.controller.version,
-                                     self.controller.build, self.controller.update, self.controller.license,
-                                     self.controller.desc, self.controller.smallIcon, self.controller.bigIcon,
+        self.helpDialog = HelpDialog(applicationInfo["name"], applicationInfo["author"], applicationInfo["copyright"],
+                                     applicationInfo["links"], applicationInfo["emails"], applicationInfo["version"],
+                                     applicationInfo["build"], applicationInfo["update"], applicationInfo["license"],
+                                     applicationInfo["desc"], applicationInfo["smallIcon"], applicationInfo["bigIcon"],
                                      qss = self.qss, parent = self.ui.centralwidget)
         self.configDialog = ConfigDialog(controller = self.controller, qss = self.qss, parent = self.ui.centralwidget)
 
@@ -244,7 +245,7 @@ class View(QtCore.QObject):
         else:
             title += ntpath.basename(str(self.controller.getProjectName()))
         
-        self.setMainWindowTitle(self.controller.name + ' ' + self.controller.getVersion() + ' - ' + title + ' - ' +
+        self.setMainWindowTitle(applicationInfo["name"] + ' ' + getVersion() + ' - ' + title + ' - ' +
                                 self.controller.getCWD())
         
     #################### ACTIONS ####################


### PR DESCRIPTION
- Application metadata is static and changes for a different reason than the main controller of the application
- The extraction is part of an effort to reduce coupling between UI and the core logic of the application