### PR TITLE
Fix progress widget hang on failed nmap report imports

### DIFF
--- a/app/importers/NmapImporter.py
+++ b/app/importers/NmapImporter.py
@@ -72,6 +72,7 @@ class NmapImporter(QtCore.QThread):
             except:
                 self.tsLog('Giving up on import due to previous errors.')
                 self.tsLog("Unexpected error: {0}".format(sys.exc_info()[0]))
+                self.updateProgressObservable.finished()
                 self.done.emit()
                 return
 
@@ -320,8 +321,8 @@ class NmapImporter(QtCore.QThread):
             session.commit()
             self.db.dbsemaphore.release()  # we are done with the DB
             self.tsLog(f"Finished in {str(time() - startTime)} seconds.")
-            self.done.emit()
             self.updateProgressObservable.finished()
+            self.done.emit()
 
             # call the scheduler (if there is no terminal output it means we imported nmap)
             self.schedule.emit(parser, self.output == '')
@@ -330,5 +331,6 @@ class NmapImporter(QtCore.QThread):
             self.tsLog('Something went wrong when parsing the nmap file..')
             self.tsLog("Unexpected error: {0}".format(sys.exc_info()[0]))
             self.tsLog(e)
-            raise
+            self.updateProgressObservable.finished()
             self.done.emit()
+            raise

--- a/controller/controller.py
+++ b/controller/controller.py
@@ -48,7 +48,11 @@ class Controller:
         self.view.startConnections()
 
         self.loadSettings()  # creation of context menu actions from settings file and set up of various settings
-        self.initNmapImporter()
+        updateProgressObservable = UpdateProgressObservable()
+        updateProgressObserver = QtUpdateProgressObserver(self.view.importProgressWidget)
+        updateProgressObservable.attach(updateProgressObserver)
+
+        self.initNmapImporter(updateProgressObservable)
         self.initPythonImporter()
         self.initScreenshooter()
         self.initBrowserOpener()
@@ -71,11 +75,7 @@ class Controller:
         self.updateOutputFolder()                                       # tell screenshooter where the output folder is
         self.view.start(title)
 
-    def initNmapImporter(self):
-        updateProgressObservable = UpdateProgressObservable()
-        updateProgressObserver = QtUpdateProgressObserver(ProgressWidget('Importing nmap..'))
-        updateProgressObservable.attach(updateProgressObserver)
-
+    def initNmapImporter(self, updateProgressObservable: UpdateProgressObservable):
         self.nmapImporter = NmapImporter(updateProgressObservable,
                                          self.logic.activeProject.repositoryContainer.hostRepository)
         self.nmapImporter.done.connect(self.importFinished)
@@ -417,7 +417,7 @@ class Controller:
                     outputfile = self.logic.activeProject.properties.runningFolder + "/" + \
                                  re.sub("[^0-9a-zA-Z]", "", str(tool)) + \
                                  "/" + getTimestamp() + '-' + tool + "-" + ip[0] + "-" + ip[1]
-                                        
+
                     command = str(self.settings.portActions[srvc_num][2])
                     command = command.replace('[IP]', ip[0]).replace('[PORT]', ip[1]).replace('[OUTPUT]', outputfile)
 

--- a/ui/view.py
+++ b/ui/view.py
@@ -491,14 +491,9 @@ class View(QtCore.QObject):
                                                       "Ok")
                 return
 
-            self.importProgressWidget.reset('Importing nmap..') 
-            self.importProgressWidget.setProgress(5)
-            self.importProgressWidget.show()
             self.controller.nmapImporter.setFilename(str(filename))
             self.controller.nmapImporter.start()
             self.controller.copyNmapXMLToOutputFolder(str(filename))
-            self.importProgressWidget.show()
-            
         else:
             log.info('No file chosen..')
 


### PR DESCRIPTION
- The progress widget created in the controller is now replaced by a single progress widget from the view which is passed down to the update progress observable, which then emits signals back to the UI on progress change events.
- When there is an exception in importing an nmap report, the progress widget gracefully hides from view, whereas before it would linger on failure.