### PR TITLE
Additional flake8 rule enforcement

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-select=E501,F841
+select=E501,F811,F823,F831,F841,E502,E703,E704,E713,E741,E742,E743,W291,W601,W602
 exclude=.git,.idea,tmp,backup,log,images,venv
 max-line-length: 120

--- a/app/auxiliary.py
+++ b/app/auxiliary.py
@@ -117,7 +117,7 @@ class Wordlist():
     def setFilename(self, filename):
         self.filename = filename
 
-    # adds a word to the wordlist (without duplicates)  
+    # adds a word to the wordlist (without duplicates)
     def add(self, word):
         with open(self.filename, 'a') as f:
             if not word + '\n' in self.wordlist:

--- a/app/settings.py
+++ b/app/settings.py
@@ -62,7 +62,7 @@ class AppSettings():
         sortArrayWithArray(sortArray, hostactions)  # sort by label so that it appears nicely in the context menu
         return hostactions
 
-    # this function fetches all the host actions from the settings file 
+    # this function fetches all the host actions from the settings file
     def getPortActions(self):
         self.actions.beginGroup('PortActions')
         portactions = []
@@ -75,7 +75,7 @@ class AppSettings():
         sortArrayWithArray(sortArray, portactions)  # sort by label so that it appears nicely in the context menu
         return portactions
 
-    # this function fetches all the port actions from the settings file 
+    # this function fetches all the port actions from the settings file
     def getPortTerminalActions(self):
         self.actions.beginGroup('PortTerminalActions')
         portactions = []
@@ -88,7 +88,7 @@ class AppSettings():
         sortArrayWithArray(sortArray, portactions)  # sort by label so that it appears nicely in the context menu
         return portactions
 
-    # this function fetches all the port actions that will be run as terminal commands from the settings file   
+    # this function fetches all the port actions that will be run as terminal commands from the settings file
     def getSchedulerSettings(self):
         settings = []
         self.actions.beginGroup('SchedulerSettings')

--- a/controller/controller.py
+++ b/controller/controller.py
@@ -569,7 +569,7 @@ class Controller:
     def getHostsForTool(self, toolName, closed='False'):
         return self.logic.activeProject.repositoryContainer.processRepository.getHostsByToolName(toolName, closed)
 
-    #################### BOTTOM PANEL INTERFACE UPDATE FUNCTIONS ####################       
+    #################### BOTTOM PANEL INTERFACE UPDATE FUNCTIONS ####################
 
     def getProcessesFromDB(self, filters, showProcesses='noNmap', sort='desc', ncol='id'):
         return self.logic.activeProject.repositoryContainer.processRepository.getProcesses(filters, showProcesses, sort,
@@ -592,7 +592,7 @@ class Controller:
                     next_proc.display.clear()
                     self.processes.append(next_proc)
                     self.fastProcessesRunning += 1
-                    # Add Timeout 
+                    # Add Timeout
                     next_proc.waitForFinished(10)
                     next_proc.start(next_proc.command)
                     self.logic.activeProject.repositoryContainer.processRepository.storeProcessRunningStatus(

--- a/parsers/Script.py
+++ b/parsers/Script.py
@@ -86,7 +86,7 @@ class Script:
             resultsDict[resultCpeData[3]] = resultCpeDetails
             count = count + 1
 
-        return resultsDict 
+        return resultsDict
 
     def getCves(self):
         cveOutput = self.output

--- a/ui/addHostDialog.py
+++ b/ui/addHostDialog.py
@@ -53,7 +53,7 @@ class AddHostsDialog(QtWidgets.QDialog):
 
         self.hlayout = QtWidgets.QHBoxLayout()
         self.hlayout.addWidget(self.lblHost)
-        self.hlayout.addWidget(self.txtHostList)        
+        self.hlayout.addWidget(self.txtHostList)
         
         self.lblHostExample = QtWidgets.QLabel(self)
         self.lblHostExample.setText('Ex: 192.168.1.0/24; 10.10.10.10-20; 1.2.3.4; bing.com')

--- a/ui/ancillaryDialog.py
+++ b/ui/ancillaryDialog.py
@@ -87,7 +87,7 @@ class ImageViewer(QtWidgets.QWidget):
                 return
 
             self.imageLabel.setPixmap(QtGui.QPixmap.fromImage(image))
-            self.scaleFactor = 1.0                
+            self.scaleFactor = 1.0
             self.fitToWindow()
 
     def zoomIn(self):

--- a/ui/dialogs.py
+++ b/ui/dialogs.py
@@ -47,10 +47,10 @@ class BruteWidget(QtWidgets.QWidget):
         self.passwordsTextinput.textEdited.connect(self.singlePassRadio.toggle)
         self.userlistTextinput.textEdited.connect(self.userListRadio.toggle)
         self.passlistTextinput.textEdited.connect(self.passListRadio.toggle)
-        self.checkAddMoreOptions.stateChanged.connect(self.showMoreOptions)     
+        self.checkAddMoreOptions.stateChanged.connect(self.showMoreOptions)
         
     def setupLayoutHlayout(self):
-        hydraServiceConversion = {'login':'rlogin', 'ms-sql-s':'mssql', 'ms-wbt-server':'rdp', 'netbios-ssn':'smb', \
+        hydraServiceConversion = {'login':'rlogin', 'ms-sql-s':'mssql', 'ms-wbt-server':'rdp', 'netbios-ssn':'smb',
             'netbios-ns':'smb', 'microsoft-ds':'smb', 'postgresql':'postgres', 'vmware-auth':'vmauthd"'}
         # sometimes nmap service name is different from hydra service name
         if self.service is None:
@@ -80,7 +80,7 @@ class BruteWidget(QtWidgets.QWidget):
         self.label3.setAlignment(Qt.AlignVCenter)
         self.serviceComboBox = QtWidgets.QComboBox()
         self.serviceComboBox.insertItems(0, self.settings.brute_services.split(","))
-        self.serviceComboBox.setStyleSheet("QComboBox { combobox-popup: 0; }");
+        self.serviceComboBox.setStyleSheet("QComboBox { combobox-popup: 0; }")
         self.serviceComboBox.currentIndexChanged.connect(self.checkSelectedService)
         
         # autoselect service from combo box
@@ -107,7 +107,7 @@ class BruteWidget(QtWidgets.QWidget):
         self.hlayout.addWidget(self.label1)
         self.hlayout.addWidget(self.ipTextinput)
         self.hlayout.addWidget(self.label2)
-        self.hlayout.addWidget(self.portTextinput)  
+        self.hlayout.addWidget(self.portTextinput)
         self.hlayout.addWidget(self.label3)
         self.hlayout.addWidget(self.serviceComboBox)
         self.hlayout.addWidget(self.runButton)
@@ -139,7 +139,7 @@ class BruteWidget(QtWidgets.QWidget):
         self.foundUsersRadio = QtWidgets.QRadioButton()
         self.label9 = QtWidgets.QLabel()
         self.label9.setText('Found usernames')
-        self.label9.setFixedWidth(117)      
+        self.label9.setFixedWidth(117)
         
         self.userGroup = QtWidgets.QButtonGroup()
         self.userGroup.addButton(self.singleUserRadio)
@@ -178,7 +178,7 @@ class BruteWidget(QtWidgets.QWidget):
         #else: This clause would produce an interesting logic error and crash
             #self.warningLabel.hide()
 
-    def setupLayoutHlayout3(self):        
+    def setupLayoutHlayout3(self):
         #add usernames wordlist
         self.singlePassRadio = QtWidgets.QRadioButton()
         self.label6 = QtWidgets.QLabel()
@@ -199,7 +199,7 @@ class BruteWidget(QtWidgets.QWidget):
         self.foundPasswordsRadio = QtWidgets.QRadioButton()
         self.label10 = QtWidgets.QLabel()
         self.label10.setText('Found passwords')
-        self.label10.setFixedWidth(115) 
+        self.label10.setFixedWidth(115)
         
         self.passGroup = QtWidgets.QButtonGroup()
         self.passGroup.addButton(self.singlePassRadio)
@@ -217,8 +217,8 @@ class BruteWidget(QtWidgets.QWidget):
         self.threadsComboBox.insertItems(0, self.threadOptions)
         self.threadsComboBox.setMinimumContentsLength(3)
         self.threadsComboBox.setMaxVisibleItems(3)
-        self.threadsComboBox.setStyleSheet("QComboBox { combobox-popup: 0; }");
-        self.threadsComboBox.setCurrentIndex(15)    
+        self.threadsComboBox.setStyleSheet("QComboBox { combobox-popup: 0; }")
+        self.threadsComboBox.setCurrentIndex(15)
     
         self.hlayout3 = QtWidgets.QHBoxLayout()
         self.hlayout3.addWidget(self.singlePassRadio)
@@ -259,7 +259,7 @@ class BruteWidget(QtWidgets.QWidget):
         self.checkExitOnValid.toggle()
         #add 'exit after first valid combination is found'
         self.checkVerbose = QtWidgets.QCheckBox()
-        self.checkVerbose.setText('Verbose')        
+        self.checkVerbose.setText('Verbose')
 
         self.checkAddMoreOptions = QtWidgets.QCheckBox()
         self.checkAddMoreOptions.setText('Additional Options')
@@ -310,7 +310,7 @@ class BruteWidget(QtWidgets.QWidget):
 
     # TODO: need to check all the methods that need an additional input field and add them here
 #   def showMoreOptions(self, text):
-#       if str(text) == "http-head":        
+#       if str(text) == "http-head":
 #           self.labelPath.show()
 #       else:
 #           self.labelPath.hide()
@@ -345,7 +345,7 @@ class BruteWidget(QtWidgets.QWidget):
         if 'form' not in str(self.service):
             self.warningLabel.hide()
         
-        if not self.service in self.settings.brute_no_username_services.split(","):
+        if self.service not in self.settings.brute_no_username_services.split(","):
             if self.singleUserRadio.isChecked():
                 self.command += " -l " + self.usersTextinput.text()
             elif self.foundUsersRadio.isChecked():
@@ -353,7 +353,7 @@ class BruteWidget(QtWidgets.QWidget):
             else:
                 self.command += " -L \"" + self.userlistTextinput.text()+"\""
                 
-        if not self.service in self.settings.brute_no_password_services.split(","):
+        if self.service not in self.settings.brute_no_password_services.split(","):
             if self.singlePassRadio.isChecked():
                 escaped_password = self.passwordsTextinput.text().replace('"', '\"\"\"')
                 self.command += " -p \"" + escaped_password + "\""
@@ -410,7 +410,7 @@ class BruteWidget(QtWidgets.QWidget):
 
         self.vlayout.addWidget(self.display)
 
-# dialog displayed when the user clicks on the advanced filters button      
+# dialog displayed when the user clicks on the advanced filters button
 class FiltersDialog(QtWidgets.QDialog):
     def __init__(self, parent=None):
         QtWidgets.QDialog.__init__(self, parent)
@@ -423,7 +423,7 @@ class FiltersDialog(QtWidgets.QDialog):
         self.setWindowTitle('Filters')
         self.setFixedSize(640, 200)
         
-        hostsBox = QGroupBox("Host Filters")        
+        hostsBox = QGroupBox("Host Filters")
         self.hostsUp = QCheckBox("Show up hosts")
         self.hostsUp.toggle()
         self.hostsDown = QCheckBox("Show down hosts")
@@ -471,14 +471,14 @@ class FiltersDialog(QtWidgets.QDialog):
         buttonLayout.addWidget(self.cancelButton)
         buttonLayout.addWidget(self.applyButton)
             
-        layout = QVBoxLayout()      
+        layout = QVBoxLayout()
         layout.addLayout(hlayout)
-        layout.addLayout(buttonLayout)  
+        layout.addLayout(buttonLayout)
         self.setLayout(layout)
         
     def getFilters(self):
-        return [self.hostsUp.isChecked(), self.hostsDown.isChecked(), self.hostsChecked.isChecked(), \
-            self.portsOpen.isChecked(), self.portsFiltered.isChecked(), self.portsClosed.isChecked(), \
+        return [self.hostsUp.isChecked(), self.hostsDown.isChecked(), self.hostsChecked.isChecked(),
+            self.portsOpen.isChecked(), self.portsFiltered.isChecked(), self.portsClosed.isChecked(),
             self.portsTcp.isChecked(), self.portsUdp.isChecked(), unicode(self.hostKeywordText.text()).split()]
 
     def setCurrentFilters(self, filters):
@@ -546,7 +546,7 @@ class HostInformationWidget(QtWidgets.QWidget):
         self.ClosedPortsLayout.addSpacing(20)
         self.ClosedPortsLayout.addWidget(self.ClosedPortsLabel)
         self.ClosedPortsLayout.addWidget(self.ClosedPortsText)
-        self.ClosedPortsLayout.addStretch() 
+        self.ClosedPortsLayout.addStretch()
         
         self.FilteredPortsLabel = QtWidgets.QLabel()
         self.FilteredPortsText = QtWidgets.QLabel()
@@ -554,7 +554,7 @@ class HostInformationWidget(QtWidgets.QWidget):
         self.FilteredPortsLayout.addSpacing(20)
         self.FilteredPortsLayout.addWidget(self.FilteredPortsLabel)
         self.FilteredPortsLayout.addWidget(self.FilteredPortsText)
-        self.FilteredPortsLayout.addStretch()   
+        self.FilteredPortsLayout.addStretch()
         ###################
         self.LocationLabel = QtWidgets.QLabel()
         self.AddressLabel = QtWidgets.QLabel()
@@ -614,7 +614,7 @@ class HostInformationWidget(QtWidgets.QWidget):
         self.dummyLayout.addWidget(self.dummyLabel)
         self.dummyLayout.addWidget(self.dummyText)
         self.dummyLayout.addStretch()
-        #########       
+        #########
         self.OSLabel = QtWidgets.QLabel()
         
         self.OSNameLabel = QtWidgets.QLabel()

--- a/ui/gui.py
+++ b/ui/gui.py
@@ -60,7 +60,7 @@ class Ui_MainWindow(object):
         self.sizePolicy2 = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
         # this specifies that the widget will expand its width when the window is resized
         self.sizePolicy2.setHorizontalStretch(1)
-        self.sizePolicy2.setVerticalStretch(0)      
+        self.sizePolicy2.setVerticalStretch(0)
         
         self.setupLeftPanel()
         self.setupRightPanel()
@@ -73,7 +73,7 @@ class Ui_MainWindow(object):
         MainWindow.setCentralWidget(self.centralwidget)
 
         self.setupMenuBar(MainWindow)
-        self.retranslateUi(MainWindow)      
+        self.retranslateUi(MainWindow)
         self.setDefaultIndexes()
         QtCore.QMetaObject.connectSlotsByName(MainWindow)
 
@@ -153,7 +153,7 @@ class Ui_MainWindow(object):
         self.ToolsTableView = QtWidgets.QTableView(self.ToolsTab)
         self.ToolsTableView.setObjectName(_fromUtf8("ToolsTableView"))
         self.horizontalLayout_3.addWidget(self.ToolsTableView)
-        self.HostsTabWidget.addTab(self.ToolsTab, _fromUtf8(""))        
+        self.HostsTabWidget.addTab(self.ToolsTab, _fromUtf8(""))
 
         # Disabled for now
         #self.CvesLeftTab = QtWidgets.QWidget()
@@ -170,7 +170,7 @@ class Ui_MainWindow(object):
         self.ServicesTabWidget.setEnabled(True)
         self.sizePolicy2.setHeightForWidth(self.ServicesTabWidget.sizePolicy().hasHeightForWidth())
         self.ServicesTabWidget.setSizePolicy(self.sizePolicy2)
-        self.ServicesTabWidget.setObjectName(_fromUtf8("ServicesTabWidget"))        
+        self.ServicesTabWidget.setObjectName(_fromUtf8("ServicesTabWidget"))
         self.splitter.addWidget(self.ServicesTabWidget)
 
         ###
@@ -184,7 +184,7 @@ class Ui_MainWindow(object):
         ###
         
         self.ToolHostsWidget = QtWidgets.QWidget()
-        self.ToolHostsWidget.setObjectName(_fromUtf8("ToolHostsTab"))       
+        self.ToolHostsWidget.setObjectName(_fromUtf8("ToolHostsTab"))
         self.ToolHostsLayout = QtWidgets.QVBoxLayout(self.ToolHostsWidget)
         self.ToolHostsLayout.setObjectName(_fromUtf8("verticalLayout"))
         self.ToolHostsTableView = QtWidgets.QTableView(self.ToolHostsWidget)
@@ -241,18 +241,18 @@ class Ui_MainWindow(object):
         self.splitter_4.setObjectName(_fromUtf8("splitter_4"))
         
         self.ScriptsTableView = QtWidgets.QTableView()
-        self.ScriptsTableView.setObjectName(_fromUtf8("ScriptsTableView"))      
+        self.ScriptsTableView.setObjectName(_fromUtf8("ScriptsTableView"))
         self.splitter_4.addWidget(self.ScriptsTableView)
         
         self.ScriptsOutputTextEdit = QtWidgets.QPlainTextEdit()
         self.ScriptsOutputTextEdit.setObjectName(_fromUtf8("ScriptsOutputTextEdit"))
-        self.ScriptsOutputTextEdit.setReadOnly(True)        
-        self.splitter_4.addWidget(self.ScriptsOutputTextEdit)       
-        self.horizontalLayout_6.addWidget(self.splitter_4)  
+        self.ScriptsOutputTextEdit.setReadOnly(True)
+        self.splitter_4.addWidget(self.ScriptsOutputTextEdit)
+        self.horizontalLayout_6.addWidget(self.splitter_4)
         self.ServicesTabWidget.addTab(self.ScriptsTab, _fromUtf8(""))
         
         self.InformationTab = QtWidgets.QWidget()
-        self.InformationTab.setObjectName(_fromUtf8("InformationTab"))          
+        self.InformationTab.setObjectName(_fromUtf8("InformationTab"))
         self.ServicesTabWidget.addTab(self.InformationTab, _fromUtf8(""))
         
         self.NotesTab = QtWidgets.QWidget()
@@ -262,14 +262,14 @@ class Ui_MainWindow(object):
         self.NotesTextEdit = QtWidgets.QPlainTextEdit(self.NotesTab)
         self.NotesTextEdit.setObjectName(_fromUtf8("NotesTextEdit"))
         self.horizontalLayout_4.addWidget(self.NotesTextEdit)
-        self.ServicesTabWidget.addTab(self.NotesTab, _fromUtf8(""))     
+        self.ServicesTabWidget.addTab(self.NotesTab, _fromUtf8(""))
 
     def setupMainTabs(self):
         self.gridLayout_2.addWidget(self.splitter, 0, 0, 1, 1)
         self.gridLayout_3 = QtWidgets.QGridLayout()
-        self.gridLayout_3.setObjectName(_fromUtf8("gridLayout_3"))  
+        self.gridLayout_3.setObjectName(_fromUtf8("gridLayout_3"))
         self.gridLayout_2.addLayout(self.gridLayout_3, 0, 0, 1, 1)
-        self.MainTabWidget.addTab(self.ScanTab, _fromUtf8(""))  
+        self.MainTabWidget.addTab(self.ScanTab, _fromUtf8(""))
         
         self.BruteTab = QtWidgets.QWidget()
         self.BruteTab.setObjectName(_fromUtf8("BruteTab"))
@@ -278,7 +278,7 @@ class Ui_MainWindow(object):
         self.BruteTabWidget = QtWidgets.QTabWidget(self.BruteTab)
         self.BruteTabWidget.setObjectName(_fromUtf8("BruteTabWidget"))
         self.horizontalLayout_7.addWidget(self.BruteTabWidget)
-        self.MainTabWidget.addTab(self.BruteTab, _fromUtf8(""))     
+        self.MainTabWidget.addTab(self.BruteTab, _fromUtf8(""))
 
     def setupBottomPanel(self):
         self.BottomTabWidget = QtWidgets.QTabWidget(self.splitter_2)
@@ -364,7 +364,7 @@ class Ui_MainWindow(object):
         self.actionHelp = QtWidgets.QAction(MainWindow)
         self.actionHelp.setObjectName(_fromUtf8("getHelp"))
         self.menuHelp.addAction(self.actionHelp)
-        self.menubar.addAction(self.menuHelp.menuAction())      
+        self.menubar.addAction(self.menuHelp.menuAction())
 
         self.actionConfig = QtWidgets.QAction(MainWindow)
         self.actionConfig.setObjectName(_fromUtf8("config"))
@@ -376,7 +376,7 @@ class Ui_MainWindow(object):
         self.HostsTabWidget.setCurrentIndex(1)
         self.ServicesTabWidget.setCurrentIndex(1)
         self.BruteTabWidget.setCurrentIndex(1)
-        self.BottomTabWidget.setCurrentIndex(0)     
+        self.BottomTabWidget.setCurrentIndex(0)
 
     def retranslateUi(self, MainWindow):
         MainWindow.setWindowTitle(QtWidgets.QApplication.translate("MainWindow", "LEGION", None))
@@ -444,4 +444,3 @@ if __name__ == "__main__":
     ui.setupUi(MainWindow)
     MainWindow.show()
     sys.exit(app.exec_())
-

--- a/ui/models/hostmodels.py
+++ b/ui/models/hostmodels.py
@@ -50,7 +50,7 @@ class HostsTableModel(QtCore.QAbstractTableModel):
     def data(self, index, role):                # this method takes care of how the information is displayed
         if role == QtCore.Qt.DecorationRole:    # to show the operating system icon instead of text
             if index.column() == 1:                                     # if trying to display the operating system
-                os_string = self.__hosts[index.row()]['osMatch']               
+                os_string = self.__hosts[index.row()]['osMatch']
                 if os_string == '':             # if there is no OS information, use the question mark icon
                     return QtGui.QIcon("./images/question-icon.png")
                     
@@ -118,7 +118,7 @@ class HostsTableModel(QtCore.QAbstractTableModel):
             
         if role == QtCore.Qt.FontRole:
             # if a host is checked strike it out and make it italic
-            if index.column() == 3 and self.__hosts[index.row()]['checked'] == 'True':  
+            if index.column() == 3 and self.__hosts[index.row()]['checked'] == 'True':
                 checkedFont=QFont()
                 checkedFont.setStrikeOut(True)
                 checkedFont.setItalic(True)

--- a/ui/models/processmodels.py
+++ b/ui/models/processmodels.py
@@ -95,7 +95,7 @@ class ProcessesTableModel(QtCore.QAbstractTableModel):
             except Exception:
                 value = "Missing data c #{0} - {1}".format(int(column), processColumns.get(int(column)))
                 pass
-            return value            
+            return value
 
     def sort(self, Ncol, order):
         self.layoutAboutToBeChanged.emit()
@@ -154,7 +154,7 @@ class ProcessesTableModel(QtCore.QAbstractTableModel):
     def getProcessPidForId(self, dbId):
         for i in range(len(self.__processes)):
             if str(self.__processes[i]['id']) == str(dbId):
-                return self.__processes[i]['pid']   
+                return self.__processes[i]['pid']
 
     def getProcessStatusForRow(self, row):
         return self.__processes[row]['status']
@@ -195,4 +195,4 @@ class ProcessesTableModel(QtCore.QAbstractTableModel):
         return self.__processes[row]['protocol']
         
     def getOutputfileForRow(self, row):
-        return self.__processes[row]['outputfile']      
+        return self.__processes[row]['outputfile']

--- a/ui/models/scriptmodels.py
+++ b/ui/models/scriptmodels.py
@@ -56,13 +56,13 @@ class ScriptsTableModel(QtCore.QAbstractTableModel):
             column = index.column()
 
             if column == 0:
-                value = self.__scripts[row]['id']        
+                value = self.__scripts[row]['id']
             elif column == 1:
                 value = self.__scripts[row]['scriptId']
             elif column == 2:
                 if self.__scripts[row]['portId'] and self.__scripts[row]['protocol'] and \
                         not self.__scripts[row]['portId'] == '' and not self.__scripts[row]['protocol'] == '':
-                    value = self.__scripts[row]['portId'] + '/' + self.__scripts[row]['protocol']              
+                    value = self.__scripts[row]['portId'] + '/' + self.__scripts[row]['protocol']
                 else:
                     value = ''
             elif column == 3:
@@ -74,10 +74,10 @@ class ScriptsTableModel(QtCore.QAbstractTableModel):
         self.layoutAboutToBeChanged.emit()
         array=[]
         
-        if Ncol == 1:            
+        if Ncol == 1:
             for i in range(len(self.__scripts)):
                 array.append(self.__scripts[i]['scriptId'])
-        if Ncol == 2:            
+        if Ncol == 2:
             for i in range(len(self.__scripts)):
                 array.append(int(self.__scripts[i]['portId']))
 

--- a/ui/models/servicemodels.py
+++ b/ui/models/servicemodels.py
@@ -131,7 +131,7 @@ class ServicesTableModel(QtCore.QAbstractTableModel):
                 array.append(self.__services[i]['name'])
             
         elif Ncol == 9:                                                 # if sorting by version
-            for i in range(len(self.__services)):           
+            for i in range(len(self.__services)):
                 value = ''
                 if not self.__services[i]['product'] == None and not self.__services[i]['product'] == '':
                     value = str(self.__services[i]['product'])
@@ -147,7 +147,7 @@ class ServicesTableModel(QtCore.QAbstractTableModel):
         sortArrayWithArray(array, self.__services)
         
         if order == Qt.AscendingOrder:                                  # reverse if needed
-            self.__services.reverse()   
+            self.__services.reverse()
             
         self.layoutChanged.emit()                           # update the UI (built-in signal)
 
@@ -163,7 +163,7 @@ class ServicesTableModel(QtCore.QAbstractTableModel):
         return self.__services[row]['ip']
         
     def getProtocolForRow(self, row):
-        return self.__services[row]['protocol']     
+        return self.__services[row]['protocol']
 
     ####################################################################
 
@@ -214,7 +214,7 @@ class ServiceNamesTableModel(QtCore.QAbstractTableModel):
         sortArrayWithArray(array, self.__serviceNames)
 
         if order == Qt.AscendingOrder:                                  # reverse if needed
-            self.__serviceNames.reverse()   
+            self.__serviceNames.reverse()
             
         self.layoutChanged.emit()                            # update the UI (built-in signal)
 

--- a/ui/settingsDialog.py
+++ b/ui/settingsDialog.py
@@ -53,7 +53,7 @@ class SettingsTabBarWidget(QtWidgets.QTabBar):
             tabRect = self.tabRect(index)
             tabRect.moveLeft(10)
             painter.drawControl(QtWidgets.QStyle.CE_TabBarTabShape, option)
-            painter.drawText(tabRect, QtCore.Qt.AlignVCenter | QtCore.Qt.TextDontClip, self.tabText(index));
+            painter.drawText(tabRect, QtCore.Qt.AlignVCenter | QtCore.Qt.TextDontClip, self.tabText(index))
         painter.end()
 
     def tabSizeHint(self,index):
@@ -146,7 +146,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.settings.general_default_terminal = str(self.terminalComboBox.currentText())
         self.settings.general_max_fast_processes = str(self.fastProcessesComboBox.currentText())
         self.settings.general_screenshooter_timeout = str(self.screenshotTextinput.text())
-        self.settings.general_web_services = str(self.webServicesTextinput.text())      
+        self.settings.general_web_services = str(self.webServicesTextinput.text())
 
         if self.checkStoreClearPW.isChecked():
             self.settings.brute_store_cleartext_passwords_on_exit = 'True'
@@ -218,7 +218,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.populateToolsTab()
         self.populateAutomatedAttacksTab()
 
-    def populateGeneralTab(self):       
+    def populateGeneralTab(self):
         self.terminalsSupported = ['gnome-terminal','xterm']
         self.terminalComboBox.insertItems(0, self.terminalsSupported)
 
@@ -236,15 +236,15 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
             self.checkStoreClearPW.toggle()
         elif self.settings.brute_store_cleartext_passwords_on_exit == 'False' and \
                 self.checkStoreClearPW.isChecked() == True:
-            self.checkStoreClearPW.toggle()     
+            self.checkStoreClearPW.toggle()
 
     def populateBruteTab(self):
         self.userlistPath.setText(self.settings.brute_username_wordlist_path)
-        self.passwordlistPath.setText(self.settings.brute_password_wordlist_path)           
+        self.passwordlistPath.setText(self.settings.brute_password_wordlist_path)
         self.defaultUserText.setText(self.settings.brute_default_username)
-        self.defaultPassText.setText(self.settings.brute_default_password)  
+        self.defaultPassText.setText(self.settings.brute_default_password)
             
-    def populateToolsTab(self): 
+    def populateToolsTab(self):
         # POPULATE TOOL PATHS TAB
         self.nmapPathInput.setText(self.settings.tools_path_nmap)
         self.hydraPathInput.setText(self.settings.tools_path_hydra)
@@ -297,7 +297,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         for keyNum in range(len(self.settings.portActions)):
             
             # populate the automated attacks tools tab with every tool that is not a default creds check
-            if self.settings.portActions[keyNum][1] not in self.defaultServicesList: 
+            if self.settings.portActions[keyNum][1] not in self.defaultServicesList:
 
                 self.typeDic[self.settings.portActions[keyNum][1]][0].setText(self.settings.portActions[keyNum][1])
                 self.typeDic[self.settings.portActions[keyNum][1]][0].setFixedWidth(150)
@@ -305,7 +305,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
                 #if self.settings.portActions[keyNum][1] in self.settings.automatedAttacks.keys():
                 foundToolInAA = False
                 for t in self.settings.automatedAttacks:
-                    if self.settings.portActions[keyNum][1] == t[0]:    
+                    if self.settings.portActions[keyNum][1] == t[0]:
                         #self.typeDic[self.settings.portActions[keyNum][1]][1].setText(
                         # self.settings.automatedAttacks[self.settings.portActions[keyNum][1]])
                         self.typeDic[self.settings.portActions[keyNum][1]][1].setText(t[1])
@@ -355,7 +355,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
                 self.defaultBoxVerlayout.addLayout(self.typeDic[self.settings.portActions[keyNum][1]][3])
 
         self.scrollArea.setWidget(self.scrollWidget)
-        self.globVerAutoToolsLayout.addWidget(self.scrollArea)      
+        self.globVerAutoToolsLayout.addWidget(self.scrollArea)
         
     ##################### SWITCH TAB FUNCTIONS #####################
 
@@ -371,7 +371,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
             # save the previous tab for the next time we switch tabs.
             # TODO: not sure this should be inside the IF but makes sense to me. no point in saving
             #  the previous if there is no change..
-            self.previousTab = self.settingsTabWidget.tabText(self.settingsTabWidget.currentIndex())            
+            self.previousTab = self.settingsTabWidget.tabText(self.settingsTabWidget.currentIndex())
         else:
             log.info('nope! cannot let you switch tab! you fucked up!')
 
@@ -601,10 +601,10 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         validationPassed = self.validatePath(self.userlistPath)
         validationPassed = self.validatePath(self.passwordlistPath) and validationPassed
         validationPassed = self.validateString(self.defaultUserText) and validationPassed
-        validationPassed = self.validateString(self.defaultPassText) and validationPassed                   
+        validationPassed = self.validateString(self.defaultPassText) and validationPassed
         return validationPassed
     
-    def toolPathsValidate(self):                
+    def toolPathsValidate(self):
         validationPassed = self.validateFile(self.nmapPathInput)
         validationPassed = self.validateFile(self.hydraPathInput) and validationPassed
         validationPassed = self.validateFile(self.cutycaptPathInput) and validationPassed
@@ -625,13 +625,13 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
             self.toggleRedBorder(nameInput, False)
 
         validationPassed = self.validateStringWithSpace(labelInput) and validationPassed
-        validationPassed = self.validateCommandFormat(commandInput) and validationPassed            
+        validationPassed = self.validateCommandFormat(commandInput) and validationPassed
         return validationPassed
 
     # avoid using the same code for the selected tab. returns the fields for the current visible tab
     # (host/ports/terminal)
     # TODO: don't like this too much. seems like we could just use parameters in the validate tool name function
-    def selectGroup(self):      
+    def selectGroup(self):
         tabSelected = -1
         
         if self.ToolSettingsTab.tabText(self.ToolSettingsTab.currentIndex()) == 'Host Commands':
@@ -695,7 +695,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
                     if tmpWidget.item(row,0).text() != str(actions[row][1]):
                         log.info('difference found')
                         actions[row][1] = tmpWidget.item(row,0).text()
-                    return self.validationPassed                
+                    return self.validationPassed
 
     #def validateUniqueKey(self, widget, tablerow, text):
     def validateUniqueToolName(self, widget, tablerow, text):
@@ -758,7 +758,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.settings.hostActions[self.hostTableRow][2] = str(self.hostCommandText.text())
 
     # update variable -> do not update the values when a line is removed
-    def updateToolForHostInformation(self, update = True):      
+    def updateToolForHostInformation(self, update = True):
         #if self.commandTabsValidate() == True:
         if self.validateCommandTabs(self.hostActionNameText, self.hostLabelText, self.hostCommandText):
 
@@ -845,7 +845,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
                         self.portActionNameText.setText(tool[1])
                         self.portLabelText.setText(tool[0])
                         self.portCommandText.setText(tool[2])
-                        #  for the case that the tool (ex. new added tool) does not have services assigned 
+                        #  for the case that the tool (ex. new added tool) does not have services assigned
                         if len(tool) == 4:
                             servicesList = tool[3].split(',')
                             self.terminalServicesActiveTable.setRowCount(len(servicesList))
@@ -909,7 +909,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
                         self.terminalActionNameText.setText(tool[1])
                         self.terminalLabelText.setText(tool[0])
                         self.terminalCommandText.setText(tool[2])
-                        #  for the case that the tool (ex. new added tool) does not have any service assigned 
+                        #  for the case that the tool (ex. new added tool) does not have any service assigned
                         if len(tool) == 4:
                             servicesList = tool[3].split(',')
                             self.terminalServicesActiveTable.setRowCount(len(servicesList))
@@ -983,11 +983,11 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.applyButton = QPushButton('Apply')
         self.applyButton.setMaximumSize(60, 30)
         self.spacer2 = QSpacerItem(750,0)
-        self.horLayout1.addItem(self.spacer2)   
+        self.horLayout1.addItem(self.spacer2)
         self.horLayout1.addWidget(self.applyButton)
         self.horLayout1.addWidget(self.cancelButton)
 
-        self.flayout.addLayout(self.horLayout1)     
+        self.flayout.addLayout(self.horLayout1)
         self.setLayout(self.flayout)
 
     def setupGeneralTab(self):
@@ -997,7 +997,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.terminalComboBox = QtWidgets.QComboBox()
         self.terminalComboBox.setFixedWidth(150)
         self.terminalComboBox.setMinimumContentsLength(3)
-        self.terminalComboBox.setStyleSheet("QComboBox { combobox-popup: 0; }");
+        self.terminalComboBox.setStyleSheet("QComboBox { combobox-popup: 0; }")
         self.terminalComboBox.setCurrentIndex(0)
         self.hlayout1 = QtWidgets.QHBoxLayout()
         self.hlayout1.addWidget(self.terminalLabel)
@@ -1013,7 +1013,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.fastProcessesComboBox = QtWidgets.QComboBox()
         self.fastProcessesComboBox.insertItems(0, self.fastProcessesNumber)
         self.fastProcessesComboBox.setMinimumContentsLength(3)
-        self.fastProcessesComboBox.setStyleSheet("QComboBox { combobox-popup: 0; }");
+        self.fastProcessesComboBox.setStyleSheet("QComboBox { combobox-popup: 0; }")
         self.fastProcessesComboBox.setCurrentIndex(19)
         self.fastProcessesComboBox.setFixedWidth(150)
         self.fastProcessesComboBox.setMaxVisibleItems(3)
@@ -1052,9 +1052,9 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.hlayout2 = QtWidgets.QHBoxLayout()
         self.hlayout2.addWidget(self.checkBlackBG)
 
-        self.vlayoutGeneral = QtWidgets.QVBoxLayout(self.GeneralSettingsTab)        
+        self.vlayoutGeneral = QtWidgets.QVBoxLayout(self.GeneralSettingsTab)
         self.vlayoutGeneral.addLayout(self.hlayout1)
-        self.vlayoutGeneral.addLayout(self.hlayoutGeneral_4)        
+        self.vlayoutGeneral.addLayout(self.hlayoutGeneral_4)
         self.vlayoutGeneral.addLayout(self.hlayoutGeneral_2)
         self.vlayoutGeneral.addLayout(self.hlayoutGeneral_3)
         self.vlayoutGeneral.addLayout(self.hlayoutGeneral_6)
@@ -1115,7 +1115,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.vlayoutBrute.addLayout(self.hlayoutGeneral_7)
         self.vlayoutBrute.addLayout(self.hlayoutGeneral_8)
         self.vlayoutBrute.addLayout(self.hlayoutGeneral_9)
-        self.vlayoutBrute.addLayout(self.hlayoutGeneral_10)     
+        self.vlayoutBrute.addLayout(self.hlayoutGeneral_10)
         self.bruteSpacer = QSpacerItem(10,380)
         self.vlayoutBrute.addItem(self.bruteSpacer)
 
@@ -1174,7 +1174,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.textEditorPathHorLayout.addWidget(self.textEditorPathInput)
         self.textEditorPathHorLayout.addStretch()
         
-        self.toolsPathVerLayout = QtWidgets.QVBoxLayout()       
+        self.toolsPathVerLayout = QtWidgets.QVBoxLayout()
         self.toolsPathVerLayout.addLayout(self.nmapPathHorLayout)
         self.toolsPathVerLayout.addLayout(self.hydraPathHorLayout)
         self.toolsPathVerLayout.addLayout(self.cutycaptPathHorLayout)
@@ -1184,7 +1184,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.globToolsPathHorLayout = QtWidgets.QHBoxLayout(self.ToolPathsWidget)
         self.globToolsPathHorLayout.addLayout(self.toolsPathVerLayout)
         self.toolsPathHorSpacer = QSpacerItem(50,0)                     # right margin spacer
-        self.globToolsPathHorLayout.addItem(self.toolsPathHorSpacer)        
+        self.globToolsPathHorLayout.addItem(self.toolsPathHorSpacer)
 
     def setupHostCommandsTab(self):
         self.toolForHostsTableWidget = QtWidgets.QTableWidget(self.HostActionsWidget)
@@ -1248,7 +1248,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.hostCommandText = QtWidgets.QLineEdit()
         self.hostCommandText.setText('init value')
         self.horLayout2.addWidget(self.label10)
-        self.horLayout2.addWidget(self.hostCommandText)     
+        self.horLayout2.addWidget(self.hostCommandText)
         
         self.spacer6 = QSpacerItem(0,20)
         self.verLayout1.addItem(self.spacer6)
@@ -1286,7 +1286,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         
         self.horLayoutPortActions = QtWidgets.QHBoxLayout()
         self.addToolButton = QPushButton('Add')
-        self.addToolButton.setMaximumSize(90, 30)       
+        self.addToolButton.setMaximumSize(90, 30)
         self.removeToolButton = QPushButton('Remove')
         self.removeToolButton.setMaximumSize(90, 30)
         self.horLayoutPortActions.addWidget(self.addToolButton)
@@ -1294,7 +1294,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
 
         self.verLayoutPortActions = QtWidgets.QVBoxLayout()
         self.verLayoutPortActions.addWidget(self.label11)
-        self.verLayoutPortActions.addWidget(self.toolForServiceTableWidget)     
+        self.verLayoutPortActions.addWidget(self.toolForServiceTableWidget)
         self.verLayoutPortActions.addLayout(self.horLayoutPortActions)
 
         self.verLayout1 = QtWidgets.QVBoxLayout()
@@ -1358,7 +1358,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.spacer4 = QSpacerItem(0,90)                                # space above and below arrow buttons
         self.verLayout2.addItem(self.spacer4)
         self.verLayout2.addWidget(self.addServicesButton)
-        self.verLayout2.addWidget(self.removeServicesButton)        
+        self.verLayout2.addWidget(self.removeServicesButton)
         self.verLayout2.addItem(self.spacer4)
         
         self.horLayout3 = QtWidgets.QHBoxLayout()                           # space left of multiple choice widget
@@ -1377,18 +1377,18 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.spacer1 = QSpacerItem(0,50)                                # bottom right space
         self.verLayout1.addItem(self.spacer1)
         
-        self.globLayoutPortActions = QtWidgets.QHBoxLayout(self.PortActionsWidget)          
+        self.globLayoutPortActions = QtWidgets.QHBoxLayout(self.PortActionsWidget)
         self.globLayoutPortActions.addLayout(self.verLayoutPortActions)
         
         self.spacer5 = QSpacerItem(10,0)                                # space between left and right layouts
-        self.globLayoutPortActions.addItem(self.spacer5)        
+        self.globLayoutPortActions.addItem(self.spacer5)
         self.globLayoutPortActions.addLayout(self.verLayout1)
         self.spacer2 = QSpacerItem(50,0)                                # right margin space
         self.globLayoutPortActions.addItem(self.spacer2)
 
-    def setupTerminalCommandsTab(self):     
+    def setupTerminalCommandsTab(self):
         self.actionTerminalLabel = QtWidgets.QLabel()
-        self.actionTerminalLabel.setText('Tools')       
+        self.actionTerminalLabel.setText('Tools')
         
         self.toolForTerminalTableWidget = QtWidgets.QTableWidget(self.portTerminalActionsWidget)
         self.toolForTerminalTableWidget.setSelectionBehavior(QAbstractItemView.SelectRows)
@@ -1398,16 +1398,16 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.toolForTerminalTableWidget.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
                                                                         # table headers
         self.toolForTerminalTableWidget.setColumnCount(1)
-        self.toolForTerminalTableWidget.setHorizontalHeaderItem(0, QtWidgets.QTableWidgetItem())        
-        self.toolForTerminalTableWidget.horizontalHeaderItem(0).setText("Name")     
-        self.toolForTerminalTableWidget.horizontalHeader().resizeSection(0,200)     
+        self.toolForTerminalTableWidget.setHorizontalHeaderItem(0, QtWidgets.QTableWidgetItem())
+        self.toolForTerminalTableWidget.horizontalHeaderItem(0).setText("Name")
+        self.toolForTerminalTableWidget.horizontalHeader().resizeSection(0,200)
         self.toolForTerminalTableWidget.horizontalHeader().setVisible(False)
         self.toolForTerminalTableWidget.verticalHeader().setVisible(False)
         self.toolForTerminalTableWidget.setVerticalHeaderItem(0, QtWidgets.QTableWidgetItem())
         
         self.horLayout1 = QtWidgets.QHBoxLayout()
         self.addToolForTerminalButton = QPushButton('Add')
-        self.addToolForTerminalButton.setMaximumSize(90, 30)        
+        self.addToolForTerminalButton.setMaximumSize(90, 30)
         self.removeToolForTerminalButton = QPushButton('Remove')
         self.removeToolForTerminalButton.setMaximumSize(90, 30)
         self.horLayout1.addWidget(self.addToolForTerminalButton)
@@ -1422,7 +1422,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.actionNameTerminalLabel = QtWidgets.QLabel()
         self.actionNameTerminalLabel.setText('Tool')
         self.actionNameTerminalLabel.setFixedWidth(70)
-        self.terminalActionNameText = QtWidgets.QLineEdit()     
+        self.terminalActionNameText = QtWidgets.QLineEdit()
         self.horLayout2.addWidget(self.actionNameTerminalLabel)
         self.horLayout2.addWidget(self.terminalActionNameText)
         
@@ -1453,7 +1453,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.terminalServicesAllTable.setHorizontalHeaderItem(0, QtWidgets.QTableWidgetItem())
         self.terminalServicesAllTable.horizontalHeaderItem(0).setText("Available Services")
         self.terminalServicesAllTable.horizontalHeader().setVisible(False)
-        self.terminalServicesAllTable.setShowGrid(False)        
+        self.terminalServicesAllTable.setShowGrid(False)
         self.terminalServicesAllTable.verticalHeader().setVisible(False)
         
         self.terminalServicesActiveTable = QtWidgets.QTableWidget()
@@ -1550,7 +1550,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.hlayout5.addWidget(self.stage5label)
         self.hlayout5.addWidget(self.stage5Input)
         
-        self.vlayout1 = QtWidgets.QVBoxLayout()     
+        self.vlayout1 = QtWidgets.QVBoxLayout()
         self.vlayout1.addLayout(self.hlayout1)
         self.vlayout1.addLayout(self.hlayout2)
         self.vlayout1.addLayout(self.hlayout3)
@@ -1576,11 +1576,11 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.globVerAutoSetLayout = QtWidgets.QVBoxLayout(self.GeneralAutoSettingsWidget)
 
         self.enableAutoAttacks = QtWidgets.QCheckBox()
-        self.enableAutoAttacks.setText('Run automated attacks') 
+        self.enableAutoAttacks.setText('Run automated attacks')
         self.checkDefaultCred = QtWidgets.QCheckBox()
         self.checkDefaultCred.setText('Check for default credentials')
 
-        self.defaultBoxVerlayout = QtWidgets.QVBoxLayout()  
+        self.defaultBoxVerlayout = QtWidgets.QVBoxLayout()
         self.defaultCredentialsBox = QGroupBox("Default Credentials")
         self.defaultCredentialsBox.setLayout(self.defaultBoxVerlayout)
         self.globVerAutoSetLayout.addWidget(self.enableAutoAttacks)
@@ -1610,7 +1610,7 @@ class AddSettingsDialog(QtWidgets.QDialog):  # dialog shown when the user select
         self.globVerAutoToolsLayout = QtWidgets.QVBoxLayout(self.AutoToolsWidget)
         self.globVerAutoToolsLayout.addLayout(self.autoToolTabHorLayout)
 
-        self.scrollVerLayout = QtWidgets.QVBoxLayout(self.scrollWidget) 
+        self.scrollVerLayout = QtWidgets.QVBoxLayout(self.scrollWidget)
         self.enabledSpacer = QSpacerItem(60,0)
         
         # by default the automated attacks are not activated and the tab is not enabled

--- a/ui/view.py
+++ b/ui/view.py
@@ -67,7 +67,7 @@ class View(QtCore.QObject):
         self.hostInfoWidget = HostInformationWidget(self.ui.InformationTab)
         self.filterdialog = FiltersDialog(self.ui.centralwidget)
         self.importProgressWidget = ProgressWidget('Importing nmap..', self.ui.centralwidget)
-        self.adddialog = AddHostsDialog(self.ui.centralwidget)      
+        self.adddialog = AddHostsDialog(self.ui.centralwidget)
         self.settingsWidget = AddSettingsDialog(self.shell, self.ui.centralwidget)
         self.helpDialog = HelpDialog(applicationInfo["name"], applicationInfo["author"], applicationInfo["copyright"],
                                      applicationInfo["links"], applicationInfo["emails"], applicationInfo["version"],
@@ -80,7 +80,7 @@ class View(QtCore.QObject):
         self.ui.ServiceNamesTableView.setSelectionMode(1)
         self.ui.CvesTableView.setSelectionMode(1)
         self.ui.ToolsTableView.setSelectionMode(1)
-        self.ui.ScriptsTableView.setSelectionMode(1)        
+        self.ui.ScriptsTableView.setSelectionMode(1)
         self.ui.ToolHostsTableView.setSelectionMode(1)
 
     # initialisations (globals, etc)
@@ -100,7 +100,7 @@ class View(QtCore.QObject):
 
         self.updateInterface()
         self.restoreToolTabWidget(True)                  # True means we want to show the original textedit
-        self.updateScriptsOutputView('')                                # update the script output panel (right) 
+        self.updateScriptsOutputView('')                                # update the script output panel (right)
         self.updateToolHostsTableView('')
         self.ui.MainTabWidget.setCurrentIndex(0)                        # display scan tab by default
         self.ui.HostsTabWidget.setCurrentIndex(0)                       # display Hosts tab by default
@@ -131,12 +131,12 @@ class View(QtCore.QObject):
         self.connectAddHosts()
         self.connectImportNmap()
         #self.connectSettings()
-        self.connectHelp()      
+        self.connectHelp()
         self.connectConfig()
         self.connectAppExit()
         ### TABLE ACTIONS ###
         self.connectAddHostsOverlayClick()
-        self.connectHostTableClick()        
+        self.connectHostTableClick()
         self.connectServiceNamesTableClick()
         self.connectToolsTableClick()
         self.connectScriptTableClick()
@@ -201,7 +201,7 @@ class View(QtCore.QObject):
         headers = ["Host", "Port", "Port", "Protocol", "State", "HostId", "ServiceId", "Name", "Product", "Version",
                    "Extrainfo", "Fingerprint"]
         setTableProperties(self.ui.ServicesTableView, len(headers), [2, 5, 6, 8, 10, 11])
-        self.ui.ServicesTableView.horizontalHeader().resizeSection(0, 130)       # resize IP 
+        self.ui.ServicesTableView.horizontalHeader().resizeSection(0, 130)       # resize IP
 
         # scripts table (right)
         headers = ["Id", "Script", "Port", "Protocol"]
@@ -278,7 +278,7 @@ class View(QtCore.QObject):
         
         return self.dealWithRunningProcesses(exiting)                   # deal with running processes
 
-    def confirmExit(self):          
+    def confirmExit(self):
         message = "Are you sure to exit the program?"
         reply = self.yesNoDialog(message, 'Confirm')
         return (reply == QtWidgets.QMessageBox.Yes)
@@ -301,7 +301,7 @@ class View(QtCore.QObject):
     def connectOpenExistingProject(self):
         self.ui.actionOpen.triggered.connect(self.openExistingProject)
 
-    def openExistingProject(self):      
+    def openExistingProject(self):
         if self.dealWithCurrentProject():
             filename = QtWidgets.QFileDialog.getOpenFileName(
                 self.ui.centralwidget, 'Open project', self.controller.getCWD(),
@@ -382,7 +382,7 @@ class View(QtCore.QObject):
                                                              filter='Legion session (*.legion)',
                                                              options=QtWidgets.QFileDialog.DontConfirmOverwrite)[0]
 
-        if not filename == '':          
+        if not filename == '':
             self.setDirty(False)
             self.viewState.firstSave = False
             self.ui.statusbar.showMessage('Saved!', msecs=1000)
@@ -414,7 +414,7 @@ class View(QtCore.QObject):
         self.ui.actionAddHosts.triggered.connect(self.connectAddHostsDialog)
         
     def connectAddHostsDialog(self):
-        self.adddialog.cmdAddButton.setDefault(True)   
+        self.adddialog.cmdAddButton.setDefault(True)
         self.adddialog.txtHostList.setFocus(True)
         self.adddialog.validationLabel.hide()
         self.adddialog.spacer.changeSize(15, 15)
@@ -467,7 +467,7 @@ class View(QtCore.QObject):
                                          scanMode=scanMode,
                                          nmapOptions=nmapOptions)
             self.adddialog.cmdAddButton.clicked.disconnect()   # disconnect all the signals from that button
-        else:       
+        else:
             self.adddialog.spacer.changeSize(0,0)
             self.adddialog.validationLabel.show()
             self.adddialog.cmdAddButton.clicked.disconnect()  # disconnect all the signals from that button
@@ -521,7 +521,7 @@ class View(QtCore.QObject):
         self.ui.actionConfig.triggered.connect(self.configDialog.show)
 
     def connectAppExit(self):
-        self.ui.actionExit.triggered.connect(self.appExit)  
+        self.ui.actionExit.triggered.connect(self.appExit)
 
     def appExit(self):
         if self.dealWithCurrentProject(True):   # the parameter indicates that we are exiting the application
@@ -552,7 +552,7 @@ class View(QtCore.QObject):
             self.ui.ServicesTabWidget.setCurrentIndex(save)
             self.updateRightPanel(self.viewState.ip_clicked)
         else:
-            self.removeToolTabs()               
+            self.removeToolTabs()
             self.updateRightPanel('')
 
     ###
@@ -714,7 +714,7 @@ class View(QtCore.QObject):
         self.ui.HostsTabWidget.currentChanged.connect(self.switchTabClick)
 
     def switchTabClick(self):
-        if self.ServiceNamesTableModel:                                 # fixes bug when switching tabs at start-up 
+        if self.ServiceNamesTableModel:                                 # fixes bug when switching tabs at start-up
             selectedTab = self.ui.HostsTabWidget.tabText(self.ui.HostsTabWidget.currentIndex())
         
             if selectedTab == 'Hosts':
@@ -733,10 +733,10 @@ class View(QtCore.QObject):
                 if self.viewState.lazy_update_hosts == True:
                     self.updateHostsTableView()
                 ###
-                self.hostTableClick()       
+                self.hostTableClick()
                     
             elif selectedTab == 'Services':
-                self.ui.ServicesTabWidget.setCurrentIndex(0)                
+                self.ui.ServicesTabWidget.setCurrentIndex(0)
                 self.removeToolTabs(0)                                  # remove the tool tabs
                 self.controller.saveProject(self.viewState.lastHostIdClicked, self.ui.NotesTextEdit.toPlainText())
                 if self.viewState.lazy_update_services == True:
@@ -898,8 +898,8 @@ class View(QtCore.QObject):
 
                 action = menu.exec_(self.ui.ToolHostsTableView.viewport().mapToGlobal(pos))
      
-                if action:                  
-                    self.controller.handlePortAction(targets, actions, terminalActions, action, restore)    
+                if action:
+                    self.controller.handlePortAction(targets, actions, terminalActions, action, restore)
             
             else:   # in case there was no port, we show the host menu (without the portscan / mark as checked)
                 menu, actions = self.controller.getContextMenuForHost(str(
@@ -934,7 +934,7 @@ class View(QtCore.QObject):
             else:
                 serviceName = '*'                                       # otherwise show full menu
                 
-            menu, actions, terminalActions = self.controller.getContextMenuForPort(serviceName)         
+            menu, actions, terminalActions = self.controller.getContextMenuForPort(serviceName)
             menu.aboutToShow.connect(self.setVisible)
             menu.aboutToHide.connect(self.setInvisible)
 
@@ -957,7 +957,7 @@ class View(QtCore.QObject):
 
             action = menu.exec_(self.ui.ServicesTableView.viewport().mapToGlobal(pos))
 
-            if action:                  
+            if action:
                 self.controller.handlePortAction(targets, actions, terminalActions, action, restore)
     
     ###
@@ -980,7 +980,7 @@ class View(QtCore.QObject):
 
             action = menu.exec_(self.ui.ProcessesTableView.viewport().mapToGlobal(pos))
 
-            if action:                                      
+            if action:
                 self.controller.handleProcessAction(selectedProcesses, action)
 
     ###
@@ -1012,7 +1012,7 @@ class View(QtCore.QObject):
             
     #################### LEFT PANEL INTERFACE UPDATE FUNCTIONS ####################
 
-    def updateHostsTableView(self): 
+    def updateHostsTableView(self):
         headers = ["Id", "OS", "Accuracy", "Host", "IPv4", "IPv6", "Mac", "Status", "Hostname", "Vendor", "Uptime",
                    "Lastboot", "Distance", "CheckedHost", "Country Code", "State", "City", "Latitude", "Longitude",
                    "Count", "Closed"]
@@ -1117,7 +1117,7 @@ class View(QtCore.QObject):
                 self.ui.ServicesTableView.setColumnHidden(i, False)
 
         for i in [0,1,5,6,8,10,11]:                                     # hide some columns
-            self.ui.ServicesTableView.setColumnHidden(i, True)      
+            self.ui.ServicesTableView.setColumnHidden(i, True)
         
         self.ServicesTableModel.sort(2, Qt.DescendingOrder)             # sort by port by default (override default)
 
@@ -1132,7 +1132,7 @@ class View(QtCore.QObject):
                 self.ui.ServicesTableView.setColumnHidden(i, False)
 
         for i in [2,5,6,7,8,10,11]:                                     # hide some columns
-            self.ui.ServicesTableView.setColumnHidden(i, True)              
+            self.ui.ServicesTableView.setColumnHidden(i, True)
         
         self.ui.ServicesTableView.horizontalHeader().resizeSection(0,165)   # resize IP
         self.ui.ServicesTableView.horizontalHeader().resizeSection(1,65)    # resize port
@@ -1144,7 +1144,7 @@ class View(QtCore.QObject):
         if hostIP:
             host = self.controller.getHostInformation(hostIP)
             
-            if host:                    
+            if host:
                 states = self.controller.getPortStatesForHost(host.id)
                 counterOpen = counterClosed = counterFiltered = 0
 
@@ -1264,7 +1264,7 @@ class View(QtCore.QObject):
         if hostIP:
             self.updateNotesView(self.HostsTableModel.getHostIdForRow(self.HostsTableModel.getRowForIp(hostIP)))
         else:
-            self.updateNotesView('')        
+            self.updateNotesView('')
             
     def displayToolPanel(self, display=False):
         size = self.ui.splitter.parentWidget().width() - self.leftPanelSize - 24       # note: 24 is a fixed value
@@ -1277,7 +1277,7 @@ class View(QtCore.QObject):
                 self.displayScreenshots(True)
             else:
                 self.displayScreenshots(False)
-                #self.ui.splitter_3.setSizes([275,size-275,0])          # reset middle panel width      
+                #self.ui.splitter_3.setSizes([275,size-275,0])          # reset middle panel width
 
         else:
             self.ui.splitter_3.hide()
@@ -1290,12 +1290,12 @@ class View(QtCore.QObject):
         if display:
             self.ui.DisplayWidget.hide()
             self.ui.ScreenshotWidget.scrollArea.show()
-            self.ui.splitter_3.setSizes([275, 0, size - 275])               # reset middle panel width  
+            self.ui.splitter_3.setSizes([275, 0, size - 275])               # reset middle panel width
 
         else:
             self.ui.ScreenshotWidget.scrollArea.hide()
             self.ui.DisplayWidget.show()
-            self.ui.splitter_3.setSizes([275, size - 275, 0])               # reset middle panel width  
+            self.ui.splitter_3.setSizes([275, size - 275, 0])               # reset middle panel width
 
     def displayAddHostsOverlay(self, display=False):
         if display:
@@ -1305,7 +1305,7 @@ class View(QtCore.QObject):
             self.ui.addHostsOverlay.hide()
             self.ui.HostsTableView.show()
             
-    #################### BOTTOM PANEL INTERFACE UPDATE FUNCTIONS ####################       
+    #################### BOTTOM PANEL INTERFACE UPDATE FUNCTIONS ####################
 
     def setupProcessesTableView(self):
         headers = ["Progress", "Display", "Elapsed", "Est. Remaining", "Pid", "Name", "Tool", "Host", "Port",
@@ -1339,7 +1339,7 @@ class View(QtCore.QObject):
         for i in columnsToHide:
             self.ui.ProcessesTableView.setColumnHidden(i, True)
         
-        # Force size of progress animation    
+        # Force size of progress animation
         self.ui.ProcessesTableView.horizontalHeader().resizeSection(0, 125)
         self.ui.ProcessesTableView.horizontalHeader().resizeSection(15, 125)
 
@@ -1377,7 +1377,7 @@ class View(QtCore.QObject):
             self.viewState.lazy_update_hosts = True
             self.viewState.lazy_update_tools = True
             
-        if self.ui.HostsTabWidget.tabText(self.ui.HostsTabWidget.currentIndex()) == 'Tools':        
+        if self.ui.HostsTabWidget.tabText(self.ui.HostsTabWidget.currentIndex()) == 'Tools':
             self.updateToolsTableView()
             self.viewState.lazy_update_hosts = True
             self.viewState.lazy_update_services = True
@@ -1454,14 +1454,14 @@ class View(QtCore.QObject):
 
         return tempTextView
 
-    def closeHostToolTab(self, index):      
+    def closeHostToolTab(self, index):
         currentTabIndex = self.ui.ServicesTabWidget.currentIndex()      # remember the currently selected tab
         self.ui.ServicesTabWidget.setCurrentIndex(index) # select the tab for which the cross button was clicked
 
         currentWidget = self.ui.ServicesTabWidget.currentWidget()
         if 'screenshot' in str(self.ui.ServicesTabWidget.currentWidget().objectName()):
             dbId = int(currentWidget.property('dbId'))
-        else:       
+        else:
             dbId = int(currentWidget.findChild(QtWidgets.QPlainTextEdit).property('dbId'))
         
         pid = int(self.controller.getPidForProcess(dbId))               # the process ID (=os)
@@ -1474,7 +1474,7 @@ class View(QtCore.QObject):
             else:
                 return
         
-        # TODO: duplicate code      
+        # TODO: duplicate code
         if str(self.controller.getProcessStatusForDBId(dbId)) == 'Waiting':
             message = "This process is waiting to start. Are you sure you want to cancel it?"
             reply = self.yesNoDialog(message, 'Confirm')
@@ -1499,12 +1499,12 @@ class View(QtCore.QObject):
             # all the tab indexes shift if we remove a tab index smaller than the current tab index
             self.ui.ServicesTabWidget.setCurrentIndex(currentTabIndex - 1)
         else:
-            self.ui.ServicesTabWidget.setCurrentIndex(currentTabIndex)  
+            self.ui.ServicesTabWidget.setCurrentIndex(currentTabIndex)
 
     # this function removes tabs that were created when running tools (starting from the end to avoid index problems)
     def removeToolTabs(self, position=-1):
         if position == -1:
-            position = self.fixedTabsCount-1        
+            position = self.fixedTabsCount-1
         for i in range(self.ui.ServicesTabWidget.count()-1, position, -1):
             self.ui.ServicesTabWidget.removeTab(i)
 
@@ -1514,7 +1514,7 @@ class View(QtCore.QObject):
         # a project is closed.
         tools = self.controller.getProcessesFromDB(self.viewState.filters, showProcesses=False)
         nbr = len(tools)  # show a progress bar because this could take long
-        if nbr==0:                                          
+        if nbr==0:
             nbr=1
         progress = 100.0 / nbr
         totalprogress = 0
@@ -1539,7 +1539,7 @@ class View(QtCore.QObject):
             tabs = self.viewState.hostTabs[ip]    # use the ip as a key to retrieve its list of tooltabs
             for tab in tabs:
                 # do not display hydra and nmap tabs when restoring for that host
-                if not 'hydra' in tab.objectName() and not 'nmap' in tab.objectName():                  
+                if 'hydra' not in tab.objectName() and 'nmap' not in tab.objectName():
                     self.ui.ServicesTabWidget.addTab(tab, tab.objectName())
 
     # this function restores the textview widget (now in the tools display widget) to its original tool tab
@@ -1551,7 +1551,7 @@ class View(QtCore.QObject):
         for host in self.viewState.hostTabs.keys():
             hosttabs = self.viewState.hostTabs[host]
             for tab in hosttabs:
-                if not 'screenshot' in str(tab.objectName()) and not tab.findChild(QtWidgets.QPlainTextEdit):
+                if 'screenshot' not in str(tab.objectName()) and not tab.findChild(QtWidgets.QPlainTextEdit):
                     tab.layout().addWidget(self.ui.DisplayWidget.findChild(QtWidgets.QPlainTextEdit))
                     break
 
@@ -1564,7 +1564,7 @@ class View(QtCore.QObject):
 
     #################### BRUTE TABS ####################
     
-    def createNewBruteTab(self, ip, port, service): 
+    def createNewBruteTab(self, ip, port, service):
         self.ui.statusbar.showMessage('Sending to Brute: '+str(ip)+':'+str(port)+' ('+str(service)+')', msecs=1000)
         bWidget = BruteWidget(ip, port, service, self.controller.getSettings())
         bWidget.runButton.clicked.connect(lambda: self.callHydra(bWidget))

--- a/utilities/qtLogging.py
+++ b/utilities/qtLogging.py
@@ -1,15 +1,11 @@
-import sys
-from PyQt5.QtGui import *                                               # for filters dialog
-from PyQt5.QtWidgets import *
-from PyQt5 import QtWidgets, QtGui
-from PyQt5 import QtCore, QtGui
+from PyQt5 import QtWidgets
 import logging
 
 class QPlainTextEditLogger(logging.Handler):
     def __init__(self, parent):
         super().__init__()
         self.widget = QtWidgets.QPlainTextEdit(parent)
-        #self.widget.setReadOnly(True)    
+        #self.widget.setReadOnly(True)
         #self.sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
         #self.sizePolicy.setHorizontalStretch(1)
         #self.sizePolicy.setVerticalStretch(1)
@@ -18,7 +14,7 @@ class QPlainTextEditLogger(logging.Handler):
 
     def emit(self, record):
         msg = self.format(record)
-        self.widget.appendPlainText(msg)    
+        self.widget.appendPlainText(msg)
 
     def append(self, msg):
         self.widget.appendPlainText(msg)


### PR DESCRIPTION
- F811 - no redefinitions of unused names
- F823 - no references of local vars before assignment
- E502 - no redundant backslashes between brackets
- E703 - no statements shall end with a semicolon
- E704 - no multiple statements on one line
- E713 - test membership should be 'not in'
- E741 - no single letter variable names like o or i
- E742 - no classes with single letter names like o or i
- E743 - no single letter functions names like o or i
- W291 - no trailing whitespace
- W601 - use  instead of  construct (which is deprecated)
- W602 - no use of deprecated exception raising