### PR TITLE
Solves issue on "command" format, where the {url} var was not being replaced on .format, resulting in cutycapt execution failure.

### DIFF
--- a/app/Screenshooter.py
+++ b/app/Screenshooter.py
@@ -74,9 +74,9 @@ class Screenshooter(QtCore.QThread):
 
     def save(self, url, ip, port, outputfile):
         self.tsLog('Saving screenshot as: ' + str(outputfile))
-        command = 'xvfb-run --server-args="-screen 0:0, 1024x768x24" /usr/bin/cutycapt --url="{url}/"' + \
-                  ' --max-wait=5000 --out="{outputfolder}/{outputfile}"' \
-                      .format(url=url, outputfolder=self.outputfolder, outputfile=outputfile)
+        command = ('xvfb-run --server-args="-screen 0:0, 1024x768x24" /usr/bin/cutycapt --url="{url}/"' + \
+                   ' --max-wait=5000 --out="{outputfolder}/{outputfile}"') \
+            .format(url=url, outputfolder=self.outputfolder, outputfile=outputfile)
         p = subprocess.Popen(command, shell=True)
         p.wait()  # wait for command to finish
         self.done.emit(ip, port, outputfile)  # send a signal to add the 'process' to the DB


### PR DESCRIPTION
On Legion (Kali 2020.2) v0.3.6-1580902879 and git downloaded v03.7-1593185290 I was unable to get screenshots on any scan. After debugging, I noticed that the "command" var was not being formatted correctly, creating a malformed call to cutycapt. The .format was being applied only to "outpufile" and "outputfolder" vars.