### PR TITLE
service-identity Python dependency moved to requirements.txt

### DIFF
--- a/deps/installPythonLibs.sh
+++ b/deps/installPythonLibs.sh
@@ -4,6 +4,5 @@ source ./deps/detectPython.sh
 
 # Setup Python deps
 ${PIP3BIN} install -r requirements.txt --upgrade
-${PIP3BIN} install service-identity --upgrade
 
 ${PYTHON3BIN} ./deps/primeExploitDb.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,5 @@ pyShodan
 GitPython
 pandas
 flake8>=3.7.8
+service-identity==21.1.0
 websockets>=9.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
service-identity was being installed out-of-band in `installPythonLibs` script but it really should be in the dependency descriptor file `requirements.txt`. This commit moves the dependency into `requirements.txt` with a pinned version for added determinism.