### PR TITLE
Added Cutycapt --insecure flag to ignore SSL/TLS certificate errors

### DIFF
--- a/app/Screenshooter.py
+++ b/app/Screenshooter.py
@@ -74,7 +74,8 @@ class Screenshooter(QtCore.QThread):
 
     def save(self, url, ip, port, outputfile):
         self.tsLog('Saving screenshot as: ' + str(outputfile))
-        command = ('xvfb-run --server-args="-screen 0:0, 1024x768x24" /usr/bin/cutycapt --url="{url}/"'
+        # Added --insecure flag to ignore SSL/TLS errors
+        command = ('xvfb-run --server-args="-screen 0:0, 1024x768x24" /usr/bin/cutycapt --insecure --url="{url}/"'
                    ' --max-wait=5000 --out="{outputfolder}/{outputfile}"') \
                   .format(url=url, outputfolder=self.outputfolder, outputfile=outputfile)
         p = subprocess.Popen(command, shell=True)


### PR DESCRIPTION
Greetings,

I found that the `Screenshooter.py` script often returned a screenshot of an "SSL handshake" error page rather than a screenshot of a web app that I had scanned.  Sometimes this was caused by self-signed certs and others because of name mismatches (IP instead of FQDN).

I found that if you added the `--insecure` flag cutycapt would ignore those errors and take the desired screenshot.  See link below.

https://sourceforge.net/p/cutycapt/code/9/

While I understand its generally not recommended to ignore these I feel that its better to do so to obtain the desired screenshot then a screenshot of an "SSL handshake" error page.  This flag was added before the `--url` flag, on line 78, and was commented in the line above it.