### PR TITLE
Fix updateProgress to always use an integer

### DIFF
--- a/app/actions/updateProgress/UpdateProgressObservable.py
+++ b/app/actions/updateProgress/UpdateProgressObservable.py
@@ -28,5 +28,7 @@ class UpdateProgressObservable(AbstractUpdateProgressObservable):
             observer.onStart()
 
     def updateProgress(self, progress):
+        progress = int(progress)
+
         for observer in self._observers:
             observer.onProgressUpdate(progress)

--- a/app/importers/NmapImporter.py
+++ b/app/importers/NmapImporter.py
@@ -114,7 +114,7 @@ class NmapImporter(QtCore.QThread):
 
                 createProgress = createProgress + ((100.0 / hostCount) / 5)
                 totalprogress = totalprogress + createProgress
-                self.updateProgressObservable.updateProgress(int(totalprogress))
+                self.updateProgressObservable.updateProgress(totalprogress)
 
             session.commit()
 
@@ -142,7 +142,7 @@ class NmapImporter(QtCore.QThread):
 
                     createOsNodesProgress = createOsNodesProgress + ((100.0 / hostCount) / 5)
                     totalprogress = totalprogress + createOsNodesProgress
-                    self.updateProgressObservable.updateProgress(int(totalprogress))
+                    self.updateProgressObservable.updateProgress(totalprogress)
 
                 session.commit()
 


### PR DESCRIPTION
This should prevent any future `float`-related issues with the `updateProgress` method. It should also resolve the issues found in:
- #228 
- #221 
- #220 